### PR TITLE
Method name not picking up correctly 

### DIFF
--- a/force-app/main/default/classes/MethodEntryExit/MethodUtility.cls
+++ b/force-app/main/default/classes/MethodEntryExit/MethodUtility.cls
@@ -81,8 +81,11 @@ public class MethodUtility {
   private static void processMethodGeneric(String line) {
     MethodSchema methodUnit = new MethodSchema();
     List<String> splitArr = line.split('\\|');
-    methodUnit.methodTitle = splitArr[splitArr.size() - 1];
-    methodUnit.methodName = methodUnit.methodTitle.substringAfterLast('.');
+    methodUnit.methodTitle = splitArr[splitArr.size() - 1]; 
+    //changed for correct method unit name
+    String s2 = '(' + methodUnit.methodTitle.substringAfterLast('(');
+    methodUnit.methodName = methodUnit.methodTitle.replace(s2,'').substringAfterLast('.')+s2;
+    //methodUnit.methodName = methodUnit.methodTitle.substringAfterLast('.');
     // System.debug('Size of the split:' + splitArr.size());
     if (splitArr.size() == 5) {
       methodUnit.classId = splitArr[splitArr.size() - 2];


### PR DESCRIPTION
Hi @charangirijala 

PFA 
![methodname](https://github.com/user-attachments/assets/f501745b-a0b5-4bff-92e7-d1a1c1224932)

Changes 
Replacing the codeline for Method name for the bug - BUG-METHOD_UNIT name picking up Incorrectly

Please review the changes 